### PR TITLE
Use html.escape() by default and fallback to cgi.escape()

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -20,7 +20,10 @@
 from __future__ import print_function
 
 import bisect
-import cgi
+try:
+    from html import escape as _escape
+except ImportError:
+    from cgi import escape as _escape
 import os
 import random
 import re
@@ -229,7 +232,7 @@ class Grammar(object):
         return ''.join(ret_list)
 
     def _generate_html_string(self, tag):
-        return cgi.escape(self._generate_string(tag), quote=True)
+        return _escape(self._generate_string(tag), quote=True)
 
     def _generate_hex(self, tag):
         """Generates a single hex digit."""


### PR DESCRIPTION
Python 3.8 removed cgi.escape(). This fixes support for all Python versions >=2.7.