### PR TITLE
Fixes path issue in php grammar file

### DIFF
--- a/canvas/canvas.txt
+++ b/canvas/canvas.txt
@@ -107,8 +107,8 @@
 
 <root root=true> = <lines count=50>
 
-!include common.txt
-!include cssproperties.txt
+!include ../common.txt
+!include ../cssproperties.txt
 
 !lineguard try { <line> } catch(e) { console.log(e.message) }
 !varformat fuzzvar%05d

--- a/grammar.py
+++ b/grammar.py
@@ -930,8 +930,7 @@ class Grammar(object):
 
     def _include_from_file(self, filename):
         try:
-            f = open(os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
+            f = open(os.path.join(self._definitions_dir,
                 filename
             ))
             content = f.read()
@@ -939,7 +938,6 @@ class Grammar(object):
         except IOError:
             print('Error reading ' + filename)
             return 1
-        self._definitions_dir = os.path.dirname(filename)
         return self.parse_from_string(content)
 
     def parse_from_string(self, grammar_str):

--- a/mathml/mathml.txt
+++ b/mathml/mathml.txt
@@ -11,7 +11,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-!include common.txt
+!include ../common.txt
 !include mathattrvalues.txt
 
 !max_recursion 50

--- a/php/php.txt
+++ b/php/php.txt
@@ -31,6 +31,7 @@
 <largeint> = 18446744073709551615
 <largeint> = 18446744073709551616
 
+
 <fuzzint> = 0
 <fuzzint> = 1
 <fuzzint> = -1
@@ -186,7 +187,7 @@
 
 <fuzzGenerator> = (function () { yield 0; })()
 
-!include php_generated.txt
+!include ./php_generated.txt
 
 ### OTHER
 

--- a/webgl/webgl.txt
+++ b/webgl/webgl.txt
@@ -515,8 +515,8 @@
 
 <root root=true> = <lines count=50>
 
-!include common.txt
-!include cssproperties.txt
+!include ../common.txt
+!include ../cssproperties.txt
 
 !lineguard try { <line> } catch(e) { }
 !varformat fuzzvar%05d


### PR DESCRIPTION
Based on how file import happens [here](https://github.com/googleprojectzero/domato/blob/master/grammar.py#L933), grammar.py was checking for php_generated.txt in the root of the project, rather than in the php directory.