### PR TITLE
Fix paths in all grammar files

### DIFF
--- a/canvas/canvas.txt
+++ b/canvas/canvas.txt
@@ -107,8 +107,8 @@
 
 <root root=true> = <lines count=50>
 
-!include ../common.txt
-!include ../cssproperties.txt
+!include ../rules/common.txt
+!include ../rules/cssproperties.txt
 
 !lineguard try { <line> } catch(e) { console.log(e.message) }
 !varformat fuzzvar%05d

--- a/generator.py
+++ b/generator.py
@@ -177,7 +177,6 @@ def generate_samples(template, outfiles):
             try:
                 with open(outfile, 'w') as f:
                     f.write(result)
-                    f.close()
             except IOError:
                 print('Error writing to output')
 
@@ -201,8 +200,7 @@ def main():
     fuzzer_dir = os.path.dirname(__file__)
 
     with open(os.path.join(fuzzer_dir, "template.html"), "r") as f:
-            template = f.read()
-            f.close()
+        template = f.read()
 
     parser = get_argument_parser()
     

--- a/mathml/mathml.txt
+++ b/mathml/mathml.txt
@@ -11,7 +11,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-!include ../common.txt
+!include ../rules/common.txt
 !include mathattrvalues.txt
 
 !max_recursion 50

--- a/webgl/webgl.txt
+++ b/webgl/webgl.txt
@@ -515,8 +515,8 @@
 
 <root root=true> = <lines count=50>
 
-!include ../common.txt
-!include ../cssproperties.txt
+!include ../rules/common.txt
+!include ../rules/cssproperties.txt
 
 !lineguard try { <line> } catch(e) { }
 !varformat fuzzvar%05d


### PR DESCRIPTION
Some paths were missed in 0422596. This also removes some redundant calls to close().