### PR TITLE
Two mathml rules were causing errors during string generation due to …

### DIFF
--- a/rules/mathml.txt
+++ b/rules/mathml.txt
@@ -50,9 +50,7 @@
 <mathmlelement_token> = <mathmlelement_mtext>
 
 # Interesting content for token elements is generally a single letter or symbol.
-<mathmlelement_token_content p=.3> = <htmlsafestring minlength=1 maxlength=1 min=32 max=126>
-<mathmlelement_token_content p=.3> = <htmlsafestring minlength=1 maxlength=1 min=0x2100 max=0x2BFF>
-<mathmlelement_token_content p=.3> = <htmlsafestring minlength=1 maxlength=1 min=0x1D400 max=0x1D7FF>
+<mathmlelement_token_content> = <htmlsafestring minlength=1 maxlength=1 min=32 max=126>
 <mathmlelement_token_content> = <htmlsafestring min=32 max=126>
 
 # Elements behaving more or less like an <mrow>.


### PR DESCRIPTION
…too large min/max values.

Removed those rules
---------------------
Sample generating was failing at line 231 in grammar.py due to calling `chr()` on values > than 255. These values were due to two rules in mathml that set large min and max values for htmlsafestring.

---------------------

Traceback (most recent call last):
--
File generator.py", line 244, in <module>
main()
File generator.py", line 216, in main
generate_samples(template, [args.file])
File generator.py", line 180, in generate_samples
result = generate_new_sample(template, htmlgrammar, cssgrammar, jsgrammar)
File generator.py", line 110, in generate_new_sample
html = htmlgrammar.generate_symbol('bodyelements')
File grammar.py", line 578, in generate_symbol
return self._generate(name, context, 0)
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 508, in _expand_rule
File grammar.py", line 431, in _generate
File grammar.py", line 490, in _expand_rule
expanded = self._built_in_types[part['tagname']](part)
File grammar.py", line 235, in _generate_html_string
return _escape(self._generate_string(tag), quote=True)
File grammar.py", line 231, in _generate_string
for _ in range(length)]
ValueError: chr() arg not in range(256)

