### PR TITLE
Add `--template` option to supply custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ To generate a single .html sample run:
 
 `python generator.py --file <output file>`
 
+To generate a single .html sample run using a template you wrote:
+
+`python generator.py --file <output file> --template <your custom template file>`
+
 To generate multiple samples with a single call run:
 
 `python generator.py --output_dir <output directory> --no_of_files <number of output files>`

--- a/generator.py
+++ b/generator.py
@@ -22,6 +22,7 @@ import os
 import re
 import random
 import argparse
+from pathlib import Path
 
 from grammar import Grammar
 from svg_tags import _SVG_TYPES
@@ -201,18 +202,18 @@ def get_argument_parser():
     parser.add_argument('-n', '--no_of_files', type=int,
                     help='number of files to be generated')
 
+    parser.add_argument('-t', '--template', type=Path, default=(Path(__file__).parent).joinpath('template.html'),
+                    help='template file you want to use')
     return parser
 
 def main():
 
-    fuzzer_dir = os.path.dirname(__file__)
-
-    with open(os.path.join(fuzzer_dir, "template.html"), "r") as f:
-        template = f.read()
-
     parser = get_argument_parser()
     
     args = parser.parse_args()
+
+    with args.template.open("r") as f:
+        template = f.read()
 
     if args.file:
         generate_samples(template, [args.file])


### PR DESCRIPTION
I've been using Domato to fuzz some APIs (e.g. DOMParser) that would benefit from using a different template from `template.html`. This PR adds the option `--template` to allow users to supply a template file for Domato to use. I thought others might find this option useful as well.

### Test Plan
- Ran Domato without supplying `python generator.py --file test.html` and Domato will use `template.html`
- Ran Domato from a directory that wasn't Domato and Domato will still use `template.html`: `python path/to/domato/generator.py --file test.html`
- Created the following test template (`test_template.html`), ran `python path/to/domato/generator.py -f test.html -t test_template.html` and the output of Domato replaced `<htmlfuzzer>` with some html generated from grammar:
```html
<!--beginhtml--><htmlfuzzer><!--endhtml-->
```