### PR TITLE
fix: fix context shallow copy

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -28,6 +28,7 @@ import os
 import random
 import re
 import struct
+import copy
 
 _INT_RANGES = {
     'int': [-2147483648, 2147483647],
@@ -283,7 +284,7 @@ class Grammar(object):
         self._add_variable('window', 'Window', context)
 
         while len(context['lines']) < num_lines:
-            tmp_context = context.copy()
+            tmp_context = copy.deepcopy(context)
             try:
                 if (random.random() < self._interesting_line_prob) and (len(tmp_context['interesting_lines']) > 0):
                     tmp_context['force_var_reuse'] = True


### PR DESCRIPTION
Classic python object shallow-copy problem.

```python
context = {
    'lastvar': last_var,
    'lines': [],
    'variables': {},
    'interesting_lines': [],
    'force_var_reuse': False
}
...
while len(context['lines']) < num_lines:
    tmp_context = context.copy()
    try:
        if (random.random() < self._interesting_line_prob) and (len(tmp_context['interesting_lines']) > 0):
            tmp_context['force_var_reuse'] = True
            lineno = random.choice(tmp_context['interesting_lines'])
        else:
            lineno = random.choice(self._all_nonhelper_lines)
        creator = self._creators['line'][lineno]
        self._expand_rule('line', creator, tmp_context, 0, False)
        context = tmp_context
    except RecursionError as e:
        print('Warning: ' + str(e))
```
When `RecursionError` is triggered, some of the generated lines are retained in the original context.
This can lead to some unintended behavior, such as variable redefinition.